### PR TITLE
Add Email Template

### DIFF
--- a/emailtemplate.txt
+++ b/emailtemplate.txt
@@ -6,9 +6,9 @@ Here’s your group for this week’s catchup:
 {person_1_name}
 {person_2_name}
 
-(in case you’re looking for other person’s email address, it’s in the recipient list)
+(in case you’re looking for other person’s email address, it’s in the recipient list of this email)
 
-Please reach out to each other and find a time over the next 7 days that suits both of you and hangout on your favorite platform. If you’re unable to make it this week for any reason, please let the other person know about your unavailability.
+Please reach out to each other and find a time slot over the next 7 days that suits both of you and hangout on your favorite platform. If you’re unable to make it this week for any reason, please let the other person know about your unavailability.
 
 The topic and length of the catch up is totally up to you to decide. While you can discuss life, universe and everything, here’s a handy list of things that you can pick from if you’re stuck - career, weather, current affairs, sports, politics and of course CSE SUST. A trip down memory lane is also always exciting!
 


### PR DESCRIPTION
Solves https://github.com/SakibulMowla/catch-up/issues/3.

## Context

Adding email template that'll be used by the periodic catch up organizer script.

## Details

I read [this article](https://www.freecodecamp.org/news/how-to-create-an-email-newsletter-design-layout-send/) before writing up this template email. Although that's for newsletter, our case is not very different and the suggestions are still useful.

> Using HTML in your email can make it look nice, certainly. However, HTML emails are more likely to be flagged as spam by the receiving providers.

^ is the reason for going with plain email. It makes our lives easier as well needless to say.

I've surrounded the parts that we need to dynamically replace within curly braces (`{}`). No specific reason for choosing curly braces over other symbols. I was just looking for some delimiter and pretty much open to other suggestions there.

I've kept the subject line in the template for now but we can move that elsewhere depending on our implementation. For example, if we end up storing the template in db, email_body column/field can store the actual template and email_subject column/field can store the subject line.
 