### PR TITLE
Reduce db timeout

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,4 @@
+module.exports = {
+  JEST_DEFAULT_TIMEOUT_MS: 5000,
+  DB_SETUP_WAIT_TIME_MS: 10 * 1000,
+};

--- a/dbwrapper.test.js
+++ b/dbwrapper.test.js
@@ -1,3 +1,4 @@
+const { JEST_DEFAULT_TIMEOUT_MS, DB_SETUP_WAIT_TIME_MS } = require('./constants');
 const DBWrapper = require('./dbwrapper');
 const delay = require('./library');
 
@@ -25,7 +26,7 @@ test('create devcatchupusers table', async () => {
 
 test('put elements in devcatchupusers table', async () => {
   // wait for db setup to finish
-  await delay(60 * 1000);
+  await delay(DB_SETUP_WAIT_TIME_MS);
 
   const batchWriteParams = {
     RequestItems: {
@@ -62,7 +63,7 @@ test('put elements in devcatchupusers table', async () => {
   const response = await dbWrapper.scan(scanParams);
 
   expect(response.Count).toBe(2);
-}, 5000 + 60 * 1000);
+}, JEST_DEFAULT_TIMEOUT_MS + DB_SETUP_WAIT_TIME_MS);
 
 test('query devcatchupusers table', async () => {
   const table = 'devcatchupusers';
@@ -88,5 +89,5 @@ test('delete devcatchupusers table', async () => {
   expect(response.TableDescription.TableStatus).toBe('DELETING');
 
   // wait for db deletion to finish
-  await delay(60 * 1000);
-}, 5000 + 60 * 1000);
+  await delay(DB_SETUP_WAIT_TIME_MS);
+}, JEST_DEFAULT_TIMEOUT_MS + DB_SETUP_WAIT_TIME_MS);

--- a/matcher.js
+++ b/matcher.js
@@ -12,8 +12,6 @@ const DevPrefix = 'dev';
 class Matcher {
   constructor(orderedAllUserList) {
     this.dbWrapper = new DBWrapper();
-    this.dynamodb = new AWS.DynamoDB();
-    this.docClient = new AWS.DynamoDB.DocumentClient();
     this.assignedUsers = new Set();
     this.orderedAllUserList = orderedAllUserList;
     this.totalUsers = this.orderedAllUserList.length;

--- a/matcher.test.js
+++ b/matcher.test.js
@@ -1,3 +1,4 @@
+const { JEST_DEFAULT_TIMEOUT_MS, DB_SETUP_WAIT_TIME_MS } = require('./constants');
 const DBWrapper = require('./dbwrapper');
 const delay = require('./library');
 const Matcher = require('./matcher');
@@ -43,7 +44,7 @@ beforeAll(async () => {
   await dbWrapper.createTable(meetingTableParams);
 
   // wait for db setup to finish
-  await delay(60 * 1000);
+  await delay(DB_SETUP_WAIT_TIME_MS);
 
   const batchWriteParams = {
     RequestItems: {
@@ -82,7 +83,7 @@ beforeAll(async () => {
     },
   };
   await dbWrapper.batchWriteItem(batchWriteParams);
-}, 5000 + 60 * 1000);
+}, JEST_DEFAULT_TIMEOUT_MS + DB_SETUP_WAIT_TIME_MS);
 
 afterAll(async () => {
   const userTableParams = {
@@ -96,8 +97,8 @@ afterAll(async () => {
   await dbWrapper.deleteTable(meetingTableParams);
 
   // wait for db deletion to finish
-  await delay(60 * 1000);
-}, 5000 + 60 * 1000);
+  await delay(DB_SETUP_WAIT_TIME_MS);
+}, JEST_DEFAULT_TIMEOUT_MS + DB_SETUP_WAIT_TIME_MS);
 
 test('xxxxxxxs', async () => {
   const dec31st2021DateString = new Date(2021, 12, 31).toISOString();

--- a/userprioritizer.test.js
+++ b/userprioritizer.test.js
@@ -1,3 +1,4 @@
+const { JEST_DEFAULT_TIMEOUT_MS, DB_SETUP_WAIT_TIME_MS } = require('./constants');
 const DBWrapper = require('./dbwrapper');
 const delay = require('./library');
 const UserPrioritizer = require('./userprioritizer');
@@ -42,7 +43,7 @@ beforeAll(async () => {
   await dbWrapper.createTable(meetingTableParams);
 
   // wait for db setup to finish
-  await delay(60 * 1000);
+  await delay(DB_SETUP_WAIT_TIME_MS);
 
   const batchWriteParams = {
     RequestItems: {
@@ -81,7 +82,7 @@ beforeAll(async () => {
     },
   };
   await dbWrapper.batchWriteItem(batchWriteParams);
-}, 5000 + 60 * 1000);
+}, JEST_DEFAULT_TIMEOUT_MS + DB_SETUP_WAIT_TIME_MS);
 
 afterAll(async () => {
   const userTableParams = {
@@ -95,8 +96,8 @@ afterAll(async () => {
   await dbWrapper.deleteTable(meetingTableParams);
 
   // wait for db deletion to finish
-  await delay(60 * 1000);
-}, 5000 + 60 * 1000);
+  await delay(DB_SETUP_WAIT_TIME_MS);
+}, JEST_DEFAULT_TIMEOUT_MS + DB_SETUP_WAIT_TIME_MS);
 
 test('user with no previous meeting should be on top of priority list', async () => {
   const dec31st2021DateString = new Date(2021, 12, 31).toISOString();


### PR DESCRIPTION
## Details

- Reduce timeout from 60s to 10s
- Create `constants.js` file
- Move timeout constants to the file
- Remove unused variables in `Matcher.js`

## Test Plan

CI 😎

## Perf

CI test time reduced from ~6 mins to ~1 min.